### PR TITLE
refactored word generation and data component codecs to use only a long for the seed of Random(), generating the list of words each time the words are needed

### DIFF
--- a/src/main/java/com/github/x3rdev/soul_forge/common/codec/AncientTabletWordListCodecs.java
+++ b/src/main/java/com/github/x3rdev/soul_forge/common/codec/AncientTabletWordListCodecs.java
@@ -6,40 +6,18 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public record AncientTabletWordListCodecs(List<String> words, boolean hasData) {
+public record AncientTabletWordListCodecs(long randomSeed, boolean hasData) {
     public static final Codec<AncientTabletWordListCodecs> WORD_LIST_CODEC = RecordCodecBuilder.create(
             instance -> instance.group(
-                    Codec.list(Codec.STRING).fieldOf("words").forGetter(AncientTabletWordListCodecs::words),
+                    Codec.LONG.fieldOf("words").forGetter(AncientTabletWordListCodecs::randomSeed),
                     Codec.BOOL.fieldOf("has_data").forGetter(AncientTabletWordListCodecs::hasData)
             ).apply(instance, AncientTabletWordListCodecs::new)
     );
 
     public static final StreamCodec<ByteBuf, AncientTabletWordListCodecs> WORD_LIST_STREAM_CODEC =
             StreamCodec.composite(
-                    ByteBufCodecs.collection(
-                            ArrayList::new,
-                            ByteBufCodecs.STRING_UTF8,
-                            64
-                    ), AncientTabletWordListCodecs::words,
+                    ByteBufCodecs.VAR_LONG, AncientTabletWordListCodecs::randomSeed,
                     ByteBufCodecs.BOOL, AncientTabletWordListCodecs::hasData,
                     AncientTabletWordListCodecs::new
             );
-
-    @Override
-    public String toString() {
-        StringBuilder s = new StringBuilder();
-        s.append("Has data: ");
-        s.append(hasData);
-        s.append("\nWords: \n");
-        for (int  i = 0; i < words.size(); i++) {
-            s.append(words.get(i));
-            if (i != words.size() - 1) {
-                s.append(", ");
-            }
-        }
-        return s.toString();
-    }
 }

--- a/src/main/java/com/github/x3rdev/soul_forge/common/item/AncientTablet.java
+++ b/src/main/java/com/github/x3rdev/soul_forge/common/item/AncientTablet.java
@@ -1,6 +1,5 @@
 package com.github.x3rdev.soul_forge.common.item;
 
-import com.github.x3rdev.soul_forge.SoulForge;
 import com.github.x3rdev.soul_forge.common.codec.AncientTabletWordListCodecs;
 import com.github.x3rdev.soul_forge.common.registry.DataComponentRegistry;
 import com.github.x3rdev.soul_forge.common.research.WordList;
@@ -23,21 +22,17 @@ import java.util.List;
 import java.util.Random;
 
 public class AncientTablet extends Item {
-    List<String> commonWords;
-    List<String> uncommonWords;
-    List<String> rareWords;
-    List<String> epicWords;
     List<String> words = new ArrayList<>();
 
-    static long seed;
     static Random random;
     boolean hasData;
+    long randomSeed;
 
     public AncientTablet() {
         super(new Item.Properties()
                 .rarity(Rarity.UNCOMMON)
                 .stacksTo(1)
-                .component(DataComponentRegistry.ANCIENT_TABLET_WORDS, new AncientTabletWordListCodecs(new ArrayList<>(), false))
+                .component(DataComponentRegistry.ANCIENT_TABLET_WORDS, new AncientTabletWordListCodecs(0, false))
         );
     }
 
@@ -49,73 +44,36 @@ public class AncientTablet extends Item {
         return result;
     }
 
+    public static long getWorldSeed(Level level) {
+        long seed = 0;
+        MinecraftServer server = Minecraft.getInstance().level.getServer();
+        IntegratedServer singlePlayerServer = Minecraft.getInstance().getSingleplayerServer();
+        if (server != null) seed = server.getWorldData().worldGenOptions().seed() % 16777216;
+        else if (singlePlayerServer != null) seed = singlePlayerServer.getWorldData().worldGenOptions().seed() % 16777216;
+        return seed;
+    }
+
+    public static DimensionDataStorage getDataStorage(Level level) {
+        DimensionDataStorage dataStorage = null;
+        MinecraftServer server = Minecraft.getInstance().level.getServer();
+        IntegratedServer singlePlayerServer = Minecraft.getInstance().getSingleplayerServer();
+        if (server != null) dataStorage = server.getLevel(level.dimension()).getDataStorage();
+        else if (singlePlayerServer != null) dataStorage = singlePlayerServer.getLevel(level.dimension()).getDataStorage();
+        return dataStorage;
+    }
+
     // if the tablet is meant to be readable before being used (such as from a research table), this method
     // can be called as long as the level is not null (hence why this logic isn't in the constructor)
     public InteractionResultHolder<ItemStack> generateWords(Level level, ItemStack itemstack) {
         // skip if tablet words have been loaded already
         if (hasData || level.isClientSide()) return InteractionResultHolder.sidedSuccess(itemstack, !level.isClientSide());
 
-        // retrieve incrementer for randomization
-        MinecraftServer server = Minecraft.getInstance().level.getServer();
-        IntegratedServer singlePlayerServer = Minecraft.getInstance().getSingleplayerServer();
-        DimensionDataStorage dataStorage;
-        if (server != null) {
-            seed = server.getWorldData().worldGenOptions().seed() % 16777216;
-            dataStorage = server.getLevel(level.dimension()).getDataStorage();
-        }
-        else if (singlePlayerServer != null) {
-            seed = singlePlayerServer.getWorldData().worldGenOptions().seed() % 16777216;
-            dataStorage = singlePlayerServer.getLevel(level.dimension()).getDataStorage();
-        }
-        else {
-            SoulForge.LOGGER.error("Seed not loaded");
-            return InteractionResultHolder.fail(itemstack);
-        }
+        DimensionDataStorage dataStorage = getDataStorage(level);
+        AncientTabletIncrementer incrementer = dataStorage.computeIfAbsent(new SavedData.Factory<>(AncientTabletIncrementer::create, AncientTabletIncrementer::load), "");
+        this.randomSeed = (getWorldSeed(level) + incrementer.getSequencerPosition()) % 16777216;
+        this.words = generateWordListFromSeed(itemstack, (int) this.randomSeed);
 
-        AncientTabletIncrementer incrementer;
-        try {
-            incrementer = dataStorage.computeIfAbsent(new SavedData.Factory<>(AncientTabletIncrementer::create, AncientTabletIncrementer::load), "");
-        } catch (NullPointerException e) {
-            SoulForge.LOGGER.error("AncientTablet incrementer could not be retrieved");
-            return InteractionResultHolder.fail(itemstack);
-        }
-
-        // set word list for new tablet
-        WordList wordList = this.builtInRegistryHolder().getData(WordList.DATA_MAP_TYPE);
-        if (wordList != null) {
-            this.commonWords = wordList.common();
-            this.uncommonWords = wordList.uncommon();
-            this.rareWords = wordList.rare();
-            this.epicWords = wordList.epic();
-        }
-        else {
-            SoulForge.LOGGER.error("Word list not loaded");
-            return InteractionResultHolder.fail(itemstack);
-        }
-
-        // assign words to tablet
-        random = new Random(seed + incrementer.getSequencerPosition());
-        // shifted binomial distribution (produces 3 to 8 words)
-        // words : 0  1  2  3  4  5  6  7  8  9 10
-        // chance: 0  0  0  1  5 10 10  5  1  0  0 (out of 32)
-        int tries = cumulative(5, random.nextInt() % 32) + 3;
-        for (int i = 0; i < tries; i++) {
-            switch (rollRarity(Math.abs(random.nextInt()))) {
-                case EPIC:
-                    this.words.add(epicWords.get(random.nextInt(epicWords.size())));
-                    break;
-                case RARE:
-                    this.words.add(rareWords.get(random.nextInt(rareWords.size())));
-                    break;
-                case UNCOMMON:
-                    this.words.add(uncommonWords.get(random.nextInt(uncommonWords.size())));
-                    break;
-                default:
-                    this.words.add(commonWords.get(random.nextInt(commonWords.size())));
-            }
-        }
-
-        itemstack.set(DataComponentRegistry.ANCIENT_TABLET_WORDS, new AncientTabletWordListCodecs(words, true));
+        itemstack.set(DataComponentRegistry.ANCIENT_TABLET_WORDS, new AncientTabletWordListCodecs(this.randomSeed, true));
         incrementer.increment();
         return InteractionResultHolder.sidedSuccess(itemstack, !level.isClientSide());
     }


### PR DESCRIPTION
Changed:
- AncientTablet.generateWords() refactored to use the static word generation method
- AncientTabletWordListCodecs now use composite(long, boolean) instead of composite(List<String>, boolean), as only the seed for Random() is needed to reproduce the word list